### PR TITLE
change from is_callable to instanceof Closure

### DIFF
--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -36,7 +36,7 @@ class Inertia {
 
     // Set Shared
     if ($shared = kirby()->option('monoeq.inertia.shared')) {
-      if ($prop instanceof \Closure) {
+      if ($shared instanceof \Closure) {
         $shared = $shared();
       }
 

--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -36,13 +36,13 @@ class Inertia {
 
     // Set Shared
     if ($shared = kirby()->option('monoeq.inertia.shared')) {
-      if (is_callable($shared)) {
+      if ($prop instanceof \Closure) {
         $shared = $shared();
       }
 
       if (is_array($shared)) {
         array_walk_recursive($shared, function (&$prop) {
-          if (is_callable($prop)) {
+          if ($prop instanceof \Closure) {
             $prop = $prop();
           }
         });

--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -24,7 +24,7 @@ class Inertia {
 
     // Call Lazy Props
     array_walk_recursive($inertia['props'], function (&$prop) {
-      if (is_callable($prop)) {
+      if ($prop instanceof \Closure) {
         $prop = $prop();
       }
     });


### PR DESCRIPTION
`is_callable($prop)` returned true for my page's title, 'collection', called Kirby's collection() function, and crashed. `$prop instanceof Closure` doesn't return true for strings so it will only call the lazy-evaluated props, as intended. Thanks for the library!