### PR TITLE
removed inertiaUri page method in favour of request.url

### DIFF
--- a/index.php
+++ b/index.php
@@ -29,10 +29,5 @@ Kirby::plugin('monoeq/inertia', [
   'controllers' => [
     'default' => require __DIR__ . '/controllers/default.php'
   ],
-  'templates' => Inertia::assignTemplates(),
-  'pageMethods' => [
-    'inertiaUri' => function () {
-      return $this->isHomePage() ? '/' : '/' . $this->uri();
-    }
-  ]
+  'templates' => Inertia::assignTemplates()
 ]);

--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -13,7 +13,7 @@ class Inertia {
         ? $template->name() 
         : $template,
       'props' => $props,
-      'url' => $request -> url() -> toString()
+      'url' => $request->url()->toString()
     ];
 
     // Set Partial

--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -13,7 +13,7 @@ class Inertia {
         ? $template->name() 
         : $template,
       'props' => $props,
-      'url' => page()->inertiaUri()
+      'url' => $request -> url() -> toString()
     ];
 
     // Set Partial


### PR DESCRIPTION
The `inertiaUri` page method returns `$page -> uri()` but that's not always right. It omits parameters and the language code (in the address bar: `en/blog/tag:dog`, in the inertia data: `/blog`). This leads to weird behaviour in the frontend. Passing `$request->url()` straight through fixes it.

This is an absolute URL, and `inertiaUri` took pains to make it a relative URL, but it seems like that doesn't matter?

It's my first time using Inertia so maybe I'm missing something.