### PR TITLE
Back to relative URLs 🤡

### DIFF
--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -7,13 +7,17 @@ use Kirby\Http\Response;
 class Inertia {
   public static function render ($template = 'app', $props = [], $viewData = []) {
     $request = kirby()->request();
+    $url = $request->url()->toString();
+    $path = parse_url($url, PHP_URL_PATH);
+    $query = parse_url($url, PHP_URL_QUERY);
+    $url = $query ? $path . "?" . $query : $path;
 
     $inertia = [
       'component' => is_a($template, 'Kirby\Cms\Template') 
         ? $template->name() 
         : $template,
       'props' => $props,
-      'url' => $request->url()->toString()
+      'url' => $url
     ];
 
     // Set Partial


### PR DESCRIPTION
I found a reason why relative URLs are better: proxies, like the one in https://github.com/brocessing/kirby-webpack . Not sure if this is a good implementation but it works for me.