### PR TITLE
Prevent deprecation error from explode

### DIFF
--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -17,7 +17,7 @@ class Inertia {
     ];
 
     // Set Partial
-    $only = array_filter(explode(',', $request->header('X-Inertia-Partial-Data')));
+    $only = array_filter(explode(',', $request->header('X-Inertia-Partial-Data') ?? ""));
     $inertia['props'] = ($only && $request->header('X-Inertia-Partial-Component') === $inertia['component'])
       ? self::getColumns($inertia['props'], $only)
       : $inertia['props'];


### PR DESCRIPTION
In PHP 8.1, passing null to `explode` is deprecated, which happens when the `X-Inertia-Partial-Data` header is not set. Passing an empty string instead is fine.